### PR TITLE
Change the position of the use statements to be added

### DIFF
--- a/src/DeclareCollectVisitor.php
+++ b/src/DeclareCollectVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Spaceman;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+class DeclareCollectVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var Node\Stmt\Declare_[]
+     */
+    public $declares = [];
+
+    public function enterNode(Node $node): void
+    {
+        if ($this->isTargetNode($node)) {
+            $this->declares[] = $node;
+        }
+    }
+
+    /**
+     * @param Node $node
+     * @return int|void
+     */
+    public function leaveNode(Node $node)
+    {
+        if ($this->isTargetNode($node)) {
+            return NodeTraverser::REMOVE_NODE;
+        }
+    }
+
+    private function isTargetNode(Node $node): bool
+    {
+        return $node instanceof Node\Stmt\Declare_;
+    }
+}

--- a/tests/Fake/Fake.php
+++ b/tests/Fake/Fake.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 use Foo\Bar;
 
 class Fake

--- a/tests/SpacemanTest.php
+++ b/tests/SpacemanTest.php
@@ -35,10 +35,12 @@ class SpacemanTest extends TestCase
         $expected = /** @lang php */<<<EOT
 <?php
 
+declare(strict_types=1);
 namespace Newname\Space;
 
 use Author, LogicException;
 use Foo\Bar;
+
 class Fake
 {
     public function run()

--- a/tests/SpacemanTest.php
+++ b/tests/SpacemanTest.php
@@ -37,6 +37,7 @@ class SpacemanTest extends TestCase
 
 namespace Newname\Space;
 
+use Author, LogicException;
 use Foo\Bar;
 class Fake
 {
@@ -47,7 +48,6 @@ class Fake
         new LogicException;
     }
 }
-use Author, LogicException;
 
 EOT;
         $this->assertSame($expected, $sourceCode);


### PR DESCRIPTION
Hi, Currently the use statements was added to the end of codes.

In generally, these are followed by the namespace declaration. So this PR changes the position of the use statement to be added.

* before

```php
<?php

namespace Newname\Space;

use Foo\Bar;
class Fake
{
    public function run()
    {
        new Author;
        new \Foo\Bar;
        new LogicException;
    }
}
use Author, LogicException; // <--- added the use statement
```

* after

```php
<?php

namespace Newname\Space;

use Author, LogicException; // <--- added the use statement
use Foo\Bar;
class Fake
{
    public function run()
    {
        new Author;
        new \Foo\Bar;
        new LogicException;
    }
}
```