### PR TITLE
fixes removes trailing slash from sourcePath

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -42,7 +42,7 @@ class Convert
 
     private function getNamespace(string $sourcePath, \SplFileInfo $phpFile) : string
     {
-        $relativePath = substr(str_replace($sourcePath, '', (string) $phpFile->getRealPath()), 1);
+        $relativePath = substr(str_replace(rtrim($sourcePath, '/'), '', (string) $phpFile->getRealPath()), 1);
         $dirName = dirname($relativePath);
         $hasDiretocty = $dirName !== '.';
 


### PR DESCRIPTION
Thank you for a very nice product!

I made the mistake of adding a trailing slash to the end of the `sourcePath` when running it.

```
$sourcePath = __DIR__ . '/service/protected/controllers/';
```

I was expecting the namespace `application/Foo` at this time, but the actual namespace is `application/oo`.

I've fixed this to remove the slash from the end of `sourcePath`, as this is a problem that I'm sure anyone but me would miss.